### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 readme = "README.md"
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["lib", "cdylib"]
 
 [dependencies]
 godot = { package = "godot", git = "https://github.com/godot-rust/gdext.git", features = ["experimental-threads", "experimental-godot-api"] }


### PR DESCRIPTION
Fixes issue where we couldn't use this crate as a dependency to other libs.